### PR TITLE
予約語を追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Values
 | Key | Value |
 | --- | ---- |
 | MODULE | `module` |
-| METHOD | `constructor,emit,addListener,removeListener,removeAllListeners,listeners,listenerCount,setMaxListeners,getMaxListeners,eventNames,on,off,once` |
+| METHOD | `constructor,emit,addListener,removeListener,removeAllListeners,listeners,listenerCount,setMaxListeners,getMaxListeners,eventNames,on,off,once,with,of` |
 
 
 

--- a/ci/shim.js
+++ b/ci/shim.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Compile to browser source
+ * Generate shims
  */
 
 'use strict'
@@ -12,7 +12,7 @@ const apeTasking = require('ape-tasking')
 const ababelES2015 = require('ababel-es2015')
 const filecopy = require('filecopy')
 
-apeTasking.runTasks('browser', [
+apeTasking.runTasks('shim', [
   () => ababelES2015('**/*.js', {
     cwd: 'lib',
     out: 'shim/browser'

--- a/lib/reserved_names.js
+++ b/lib/reserved_names.js
@@ -7,4 +7,4 @@
 exports.MODULE = 'module'
 
 /** Reserved method names */
-exports.METHOD = 'constructor,emit,addListener,removeListener,removeAllListeners,listeners,listenerCount,setMaxListeners,getMaxListeners,eventNames,on,off,once'
+exports.METHOD = 'constructor,emit,addListener,removeListener,removeAllListeners,listeners,listenerCount,setMaxListeners,getMaxListeners,eventNames,on,off,once,with,of'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sugo-constants",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Constant variables for SUGOS",
   "main": "lib",
   "browser": "shim/browser",


### PR DESCRIPTION
一つのモジュールに複数のユーザがいる時にscopeをうまく分けるための実装が必要になる。その対応のための予約語を追加した。

以下のように、`with`でscopeを割り当てられる仕様にする想定
 
```javascript
'use strict'

const sugoCaller = require('sugo-caller')
const sugoScope = require('sugo-scope')
const co = require('co')

co(function * () {
  let caller = sugoCaller({
    port: 3000,
    hostname: 'localhost'
  })
  let scope = sugoScope()

  let shoppingMall = yield caller.connect('shoppingMall')

  // Login and store session in scope
  let signature = yield shoppingMall.get('auth').signin('user01', 'xxx-password-01')
  scope.set('who', signature)

  // Access to module with a scope
  let fruitShop = shoppingMall.get('fruitShop').with(scope)
  yield fruitShop.buy('Orange', 3)
}).catch((err) => console.error(err))

```