### PR TITLE
moduleに予約したattributeを追加した

### DIFF
--- a/lib/reserved_names.js
+++ b/lib/reserved_names.js
@@ -8,3 +8,6 @@ exports.MODULE = 'module'
 
 /** Reserved method names */
 exports.METHOD = 'constructor,emit,addListener,removeListener,removeAllListeners,listeners,listenerCount,setMaxListeners,getMaxListeners,eventNames,on,off,once,with,of'
+
+/** Reserve attribute names */
+exports.ATTRIBUTE = 'name,prototype,caller'


### PR DESCRIPTION
sugo-moduleに「name」やら「prototype」といったメソッドを定義されたら困るので予約語に追加

https://github.com/realglobe-Inc/sugo-module-base/issues/5